### PR TITLE
feat(pwa): botão "Atualizar agora" para atualização imediata do PWA

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -31,3 +31,10 @@ self.addEventListener('activate', event => {
     )
   );
 });
+
+// Permite skipWaiting via mensagem
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,0 +1,22 @@
+// Utilitário genérico para registrar o service worker e monitorar updates
+export function registerSW(onUpdate?: (registration: ServiceWorkerRegistration) => void) {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/service-worker.js').then(registration => {
+        registration.onupdatefound = () => {
+          const installingWorker = registration.installing;
+          if (installingWorker) {
+            installingWorker.onstatechange = () => {
+              if (
+                installingWorker.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                onUpdate?.(registration);
+              }
+            };
+          }
+        };
+      });
+    });
+  }
+}


### PR DESCRIPTION
- Cria utilitário src/serviceWorkerRegistration.ts para registro do service worker e detecção de atualizações.
- Adiciona suporte ao comando 'SKIP_WAITING' no service worker (public/service-worker.js).
- Altera App.tsx para exibir botão "Atualizar agora" quando há nova versão disponível, permitindo atualização imediata sem reinstalação do PWA.
- Melhoria de UX para updates progressivos e gerenciamento de cache.

Refs: atualização automática PWA, melhores práticas Vite/React.