### PR TITLE
Fix: Unifica tipos de filtros do Mapa de Parceiros

### DIFF
--- a/src/components/mapa-parceiros/MapaParceirosSidebar.tsx
+++ b/src/components/mapa-parceiros/MapaParceirosSidebar.tsx
@@ -6,15 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { ChevronDown, ChevronRight, Users } from 'lucide-react';
-import { EtapaJornada, SubnivelEtapa } from '@/types/mapa-parceiros';
-
-type FiltrosParceiros = {
-  busca?: string;
-  status?: string;
-  etapaId?: string;
-  subnivelId?: string;
-  apenasSemEtapa?: boolean;
-};
+import { EtapaJornada, SubnivelEtapa, MapaParceirosFiltros } from '@/types/mapa-parceiros';
 
 interface MapaParceirosStats {
   parceirosPorEtapa: Record<string, number>;
@@ -24,9 +16,9 @@ interface MapaParceirosStats {
 interface MapaParceirosSidebarProps {
   etapas: EtapaJornada[];
   subniveis: SubnivelEtapa[];
-  filtros: FiltrosParceiros;
+  filtros: MapaParceirosFiltros;
   stats: MapaParceirosStats;
-  onFiltrosChange: (filtros: FiltrosParceiros) => void;
+  onFiltrosChange: (filtros: MapaParceirosFiltros) => void;
   onEtapaClick: (etapaId: string) => void;
   etapaSelecionada?: string;
   expandedEtapas: Set<string>;

--- a/src/components/mapa-parceiros/MapaParceirosTable.tsx
+++ b/src/components/mapa-parceiros/MapaParceirosTable.tsx
@@ -1,27 +1,19 @@
 
 import React, { useState } from 'react';
-import { ParceiroMapa, AssociacaoParceiroEtapa, EtapaJornada, SubnivelEtapa } from '@/types/mapa-parceiros';
+import { ParceiroMapa, AssociacaoParceiroEtapa, EtapaJornada, SubnivelEtapa, MapaParceirosFiltros } from '@/types/mapa-parceiros';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Edit, Trash2 } from 'lucide-react';
-
-type FiltrosParceiros = {
-  status?: string;
-  etapaId?: string;
-  subnivelId?: string;
-  apenasSemEtapa?: boolean;
-  busca?: string;
-};
 
 interface MapaParceirosTableProps {
   parceiros: ParceiroMapa[];
   associacoes: AssociacaoParceiroEtapa[];
   etapas: EtapaJornada[];
   subniveis: SubnivelEtapa[];
-  filtros: FiltrosParceiros;
+  filtros: MapaParceirosFiltros;
   onParceiroClick: (parceiro: ParceiroMapa) => void;
   onDeletarParceiro: (parceiro: ParceiroMapa) => void;
-  onFiltrosChange: (filtros: FiltrosParceiros) => void;
+  onFiltrosChange: (filtros: MapaParceirosFiltros) => void;
   onLimparFiltros: () => void;
 }
 

--- a/src/pages/mapa-parceiros/MapaParceirosPage.tsx
+++ b/src/pages/mapa-parceiros/MapaParceirosPage.tsx
@@ -14,18 +14,10 @@ import ParceiroDetalhesSimplificado from '@/components/mapa-parceiros/ParceiroDe
 import EmpresaSelector from '@/components/mapa-parceiros/EmpresaSelector';
 import JornadaVisualization from '@/components/mapa-parceiros/JornadaVisualization';
 import MapaParceirosTable from '@/components/mapa-parceiros/MapaParceirosTable';
-import { ParceiroMapa, AssociacaoParceiroEtapa, EtapaJornada } from '@/types/mapa-parceiros';
+import { ParceiroMapa, AssociacaoParceiroEtapa, EtapaJornada, MapaParceirosFiltros } from '@/types/mapa-parceiros';
 import { DemoModeIndicator } from '@/components/privacy/DemoModeIndicator';
 import { DemoModeToggle } from '@/components/privacy/DemoModeToggle';
 import { useIsMobile } from '@/hooks/use-mobile';
-
-// Novo tipo de filtro
-type FiltrosParceiros = {
-  status?: string;
-  etapaId?: string;
-  subnivelId?: string;
-  apenasSemEtapa?: boolean;
-};
 
 const MapaParceirosPage: React.FC = () => {
   const navigate = useNavigate();
@@ -51,7 +43,8 @@ const MapaParceirosPage: React.FC = () => {
   const [showDetalhes, setShowDetalhes] = useState(false);
   const [showEmpresaSelector, setShowEmpresaSelector] = useState(false);
   const [visualizacao, setVisualizacao] = useState<'jornada' | 'grid'>('jornada');
-  const [filtrosLocal, setFiltrosLocal] = useState<FiltrosParceiros>({
+  const [filtrosLocal, setFiltrosLocal] = useState<MapaParceirosFiltros>({
+    busca: '',
     status: '',
     etapaId: '',
     subnivelId: '',
@@ -60,17 +53,19 @@ const MapaParceirosPage: React.FC = () => {
 
   // Função para limpar todos os filtros
   const handleLimparFiltros = () => {
-    setFiltrosLocal({
+    const filtrosVazios: MapaParceirosFiltros = {
+      busca: '',
       status: '',
       etapaId: '',
       subnivelId: '',
       apenasSemEtapa: false,
-    });
-    setFiltros({});
+    };
+    setFiltrosLocal(filtrosVazios);
+    setFiltros(filtrosVazios);
   };
 
   // Função para atualizar filtros simultaneamente
-  const handleAtualizarFiltros = (atualizacoes: Partial<FiltrosParceiros>) => {
+  const handleAtualizarFiltros = (atualizacoes: Partial<MapaParceirosFiltros>) => {
     const novosFiltros = { ...filtrosLocal, ...atualizacoes };
     setFiltrosLocal(novosFiltros);
     setFiltros(novosFiltros);

--- a/src/types/mapa-parceiros.ts
+++ b/src/types/mapa-parceiros.ts
@@ -56,9 +56,11 @@ export interface AssociacaoParceiroEtapa {
 }
 
 export interface MapaParceirosFiltros {
-  etapa?: string;
-  status?: string;
   busca?: string;
+  status?: string;
+  etapaId?: string;
+  subnivelId?: string;
+  apenasSemEtapa?: boolean;
 }
 
 export interface MapaParceirosStats {


### PR DESCRIPTION
Corrigi uma inconsistência entre a definição local de FiltrosParceiros e o tipo global MapaParceirosFiltros, que provavelmente causava erros no carregamento da página Mapa de Parceiros.

- Atualizei MapaParceirosFiltros em src/types/mapa-parceiros.ts para incluir todos os campos de filtro utilizados (busca, status, etapaId, subnivelId, apenasSemEtapa).
- Removi a definição local de FiltrosParceiros em MapaParceirosPage.tsx e utilizei o tipo global importado.
- Atualizei a inicialização do estado filtrosLocal e as funções de manipulação de filtro em MapaParceirosPage.tsx para refletir a estrutura completa do tipo MapaParceirosFiltros.
- Atualizei os componentes MapaParceirosSidebar.tsx e MapaParceirosTable.tsx para utilizarem o tipo importado MapaParceirosFiltros em suas props.